### PR TITLE
fix: expand refuge not worked for mp and coop

### DIFF
--- a/Contents/mods/myspatialrefuge/42.13/mod.info
+++ b/Contents/mods/myspatialrefuge/42.13/mod.info
@@ -1,6 +1,6 @@
 name=My Spatial Refuge
 id=myspatialrefuge
-modversion=1.16
+modversion=1.16.2
 icon=icon.png
 poster=poster.png
 description=Escape the apocalypse to your personal refuge. <LINE><LINE>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes upgrade handler registration so upgrades execute in MP/coop.
> 
> - Register built-in handlers on `OnGameStart` for singleplayer and `OnServerStarted` for servers; add guard to avoid duplicate registration and debug logs
> - Minor: add handler table type annotation and small logging tweaks
> - Bump `modversion` to `1.16.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68fba7590087cb2aacdf67ebec7f3bb0d1991fc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->